### PR TITLE
Fix server startup logic for production deployment

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -476,15 +476,16 @@ export async function createServer() {
   return app;
 }
 
-// Start the server only in production or when not running via Vite
+// Start the server only in development mode when not running via Vite
+// In production, node-build.ts is the entry point
 const PORT = process.env.PORT || 3000;
 const isViteMode =
   process.env.VITE_MODE || process.env.NODE_ENV === "development";
 
-// Prevent server startup during build process
-const isBuildMode = process.env.NODE_ENV === "production" && !process.env.PORT;
+// Prevent server startup during build process or in production (node-build.ts handles production)
+const isBuildMode = process.env.NODE_ENV === "production";
 
-// Only start standalone server if not running via Vite dev server and not in build mode
+// Only start standalone server if not running via Vite dev server and not in production/build mode
 if (!isViteMode && !isBuildMode) {
   createServer().then((app) => {
     app.listen(PORT, () => {

--- a/server/node-build.ts
+++ b/server/node-build.ts
@@ -2,8 +2,7 @@ import path from "path";
 import { createServer } from "./index";
 import * as express from "express";
 
-const port =
-  process.env.PORT || (process.env.NODE_ENV === "production" ? 8080 : 3000);
+const port = process.env.PORT || 10000;
 
 // Initialize server asynchronously
 async function initializeServer() {


### PR DESCRIPTION
## Purpose
The user was experiencing deployment failures across different platforms. The issue was related to server startup logic that was preventing proper initialization in production environments. This fix addresses the deployment configuration to ensure the server starts correctly in production.

## Code changes
- **Updated server startup conditions**: Modified `server/index.ts` to prevent server startup in production mode, clarifying that `node-build.ts` handles production entry
- **Simplified production port logic**: Changed `server/node-build.ts` to use port 10000 as default instead of conditional 8080/3000 logic
- **Improved comments**: Added clearer documentation explaining the separation between development and production server entry points
- **Fixed build mode detection**: Updated condition to properly detect production/build mode and prevent conflicts during deployment

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7ae4da599f664b8daa63c577ca747a47/spark-garden)

👀 [Preview Link](https://7ae4da599f664b8daa63c577ca747a47-spark-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7ae4da599f664b8daa63c577ca747a47</projectId>-->
<!--<branchName>spark-garden</branchName>-->