### PR TITLE
Fix API service configuration and env variable naming

### DIFF
--- a/server/lib/amadeusService.ts
+++ b/server/lib/amadeusService.ts
@@ -3,11 +3,20 @@ import Amadeus from "amadeus";
 // Initialize Amadeus client only if credentials are available
 let amadeus: Amadeus | null = null;
 
-if (process.env.AMADEUS_API_KEY && process.env.AMADEUS_API_SECRET) {
+// Support both naming conventions for env vars
+const AMADEUS_CLIENT_ID =
+  process.env.AMADEUS_CLIENT_ID || process.env.AMADEUS_API_KEY;
+const AMADEUS_CLIENT_SECRET =
+  process.env.AMADEUS_CLIENT_SECRET || process.env.AMADEUS_API_SECRET;
+const AMADEUS_HOSTNAME =
+  process.env.AMADEUS_HOSTNAME ||
+  (process.env.NODE_ENV === "production" ? "production" : "test"); // 'test' for sandbox, 'production' for live
+
+if (AMADEUS_CLIENT_ID && AMADEUS_CLIENT_SECRET) {
   amadeus = new Amadeus({
-    clientId: process.env.AMADEUS_API_KEY,
-    clientSecret: process.env.AMADEUS_API_SECRET,
-    hostname: process.env.NODE_ENV === "production" ? "production" : "test", // 'test' for sandbox, 'production' for live
+    clientId: AMADEUS_CLIENT_ID,
+    clientSecret: AMADEUS_CLIENT_SECRET,
+    hostname: AMADEUS_HOSTNAME,
   });
 }
 

--- a/server/lib/stripeService.ts
+++ b/server/lib/stripeService.ts
@@ -5,7 +5,7 @@ let stripe: Stripe | null = null;
 
 if (process.env.STRIPE_SECRET_KEY) {
   stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-    apiVersion: "2025-07-30.basil",
+    apiVersion: "2024-12-18.acacia",
   });
 }
 

--- a/server/routes/amadeus.ts
+++ b/server/routes/amadeus.ts
@@ -316,7 +316,7 @@ export const handleAmadeusHealthCheck: RequestHandler = async (req, res) => {
     res.json({
       success: true,
       message: "Amadeus service is operational",
-      configured: !!process.env.AMADEUS_API_KEY,
+      configured: !!(process.env.AMADEUS_CLIENT_ID || process.env.AMADEUS_API_KEY),
       environment:
         process.env.NODE_ENV === "production" ? "production" : "test",
       testResult: testResult.length > 0 ? "passed" : "no_results",
@@ -326,7 +326,7 @@ export const handleAmadeusHealthCheck: RequestHandler = async (req, res) => {
     res.status(500).json({
       success: false,
       message: "Amadeus service health check failed",
-      configured: !!process.env.AMADEUS_API_KEY,
+      configured: !!(process.env.AMADEUS_CLIENT_ID || process.env.AMADEUS_API_KEY),
       error: process.env.NODE_ENV === "development" ? error.message : undefined,
     });
   }

--- a/server/routes/amadeus.ts
+++ b/server/routes/amadeus.ts
@@ -316,7 +316,9 @@ export const handleAmadeusHealthCheck: RequestHandler = async (req, res) => {
     res.json({
       success: true,
       message: "Amadeus service is operational",
-      configured: !!(process.env.AMADEUS_CLIENT_ID || process.env.AMADEUS_API_KEY),
+      configured: !!(
+        process.env.AMADEUS_CLIENT_ID || process.env.AMADEUS_API_KEY
+      ),
       environment:
         process.env.NODE_ENV === "production" ? "production" : "test",
       testResult: testResult.length > 0 ? "passed" : "no_results",
@@ -326,7 +328,9 @@ export const handleAmadeusHealthCheck: RequestHandler = async (req, res) => {
     res.status(500).json({
       success: false,
       message: "Amadeus service health check failed",
-      configured: !!(process.env.AMADEUS_CLIENT_ID || process.env.AMADEUS_API_KEY),
+      configured: !!(
+        process.env.AMADEUS_CLIENT_ID || process.env.AMADEUS_API_KEY
+      ),
       error: process.env.NODE_ENV === "development" ? error.message : undefined,
     });
   }


### PR DESCRIPTION
## Purpose
The user was experiencing issues with API keys not working despite adding them to environment variables both locally and on Digital Ocean. Multiple services were failing including PayPal, Stripe, Sendgrid, and Amadeus. The user also requested help with renaming Amadeus environment variables to follow proper naming conventions.

## Code changes
- **Amadeus Service**: Added support for both `AMADEUS_CLIENT_ID`/`AMADEUS_CLIENT_SECRET` and legacy `AMADEUS_API_KEY`/`AMADEUS_API_SECRET` environment variable naming conventions
- **Amadeus Service**: Added configurable `AMADEUS_HOSTNAME` environment variable with fallback to automatic environment detection
- **Stripe Service**: Updated API version from `2025-07-30.basil` to `2024-12-18.acacia` for compatibility
- **Amadeus Health Check**: Updated configuration detection to check for both new and legacy environment variable names

These changes provide backward compatibility while supporting the correct Amadeus API naming conventions and ensure proper service initialization.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7ae4da599f664b8daa63c577ca747a47/flare-home)

👀 [Preview Link](https://7ae4da599f664b8daa63c577ca747a47-flare-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7ae4da599f664b8daa63c577ca747a47</projectId>-->
<!--<branchName>flare-home</branchName>-->