### PR TITLE
Add mobile hamburger menu to static pages

### DIFF
--- a/client/components/MobileNav.tsx
+++ b/client/components/MobileNav.tsx
@@ -8,150 +8,152 @@ interface MobileNavProps {
   className?: string;
 }
 
-const MobileNav: React.FC<MobileNavProps> = memo(({ handleBookNow, className }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const navigate = useNavigate();
-  const { user, logout, isAuthenticated } = useAuth();
+const MobileNav: React.FC<MobileNavProps> = memo(
+  ({ handleBookNow, className }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const navigate = useNavigate();
+    const { user, logout, isAuthenticated } = useAuth();
 
-  const closeMenu = useCallback(() => setIsOpen(false), []);
+    const closeMenu = useCallback(() => setIsOpen(false), []);
 
-  const handleNavigation = useCallback(
-    (path: string) => {
-      navigate(path);
+    const handleNavigation = useCallback(
+      (path: string) => {
+        navigate(path);
+        closeMenu();
+      },
+      [navigate, closeMenu],
+    );
+
+    const handleLogout = useCallback(() => {
+      logout();
+      navigate("/");
       closeMenu();
-    },
-    [navigate, closeMenu],
-  );
+    }, [logout, navigate, closeMenu]);
 
-  const handleLogout = useCallback(() => {
-    logout();
-    navigate("/");
-    closeMenu();
-  }, [logout, navigate, closeMenu]);
+    const handleBookNowClick = useCallback(() => {
+      handleBookNow();
+      closeMenu();
+    }, [handleBookNow, closeMenu]);
 
-  const handleBookNowClick = useCallback(() => {
-    handleBookNow();
-    closeMenu();
-  }, [handleBookNow, closeMenu]);
+    const toggleMenu = useCallback(() => setIsOpen((prev) => !prev), []);
 
-  const toggleMenu = useCallback(() => setIsOpen((prev) => !prev), []);
+    return (
+      <div className={className ?? "md:hidden"}>
+        {/* Hamburger Button */}
+        <button
+          onClick={toggleMenu}
+          className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+          aria-label="Toggle menu"
+        >
+          {isOpen ? (
+            <X className="w-6 h-6 text-brand-text-primary" />
+          ) : (
+            <Menu className="w-6 h-6 text-brand-text-primary" />
+          )}
+        </button>
 
-  return (
-    <div className={className ?? "md:hidden"}>
-      {/* Hamburger Button */}
-      <button
-        onClick={toggleMenu}
-        className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
-        aria-label="Toggle menu"
-      >
-        {isOpen ? (
-          <X className="w-6 h-6 text-brand-text-primary" />
-        ) : (
-          <Menu className="w-6 h-6 text-brand-text-primary" />
+        {/* Mobile Menu Overlay */}
+        {isOpen && (
+          <div className="fixed inset-0 z-50 bg-black/50" onClick={closeMenu} />
         )}
-      </button>
 
-      {/* Mobile Menu Overlay */}
-      {isOpen && (
-        <div className="fixed inset-0 z-50 bg-black/50" onClick={closeMenu} />
-      )}
+        {/* Mobile Menu */}
+        <div
+          className={`fixed top-0 right-0 h-full w-64 bg-white shadow-xl z-50 transform transition-transform duration-300 ease-in-out ${
+            isOpen ? "translate-x-0" : "translate-x-full"
+          }`}
+        >
+          <div className="flex flex-col h-full">
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 border-b">
+              <img
+                src="/onboard/logos.png"
+                alt="OnboardTicket Logo"
+                className="h-24 w-auto object-contain"
+              />
+              <button
+                onClick={closeMenu}
+                className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+                aria-label="Close menu"
+              >
+                <X className="w-5 h-5 text-brand-text-primary" />
+              </button>
+            </div>
 
-      {/* Mobile Menu */}
-      <div
-        className={`fixed top-0 right-0 h-full w-64 bg-white shadow-xl z-50 transform transition-transform duration-300 ease-in-out ${
-          isOpen ? "translate-x-0" : "translate-x-full"
-        }`}
-      >
-        <div className="flex flex-col h-full">
-          {/* Header */}
-          <div className="flex items-center justify-between p-4 border-b">
-            <img
-              src="/onboard/logos.png"
-              alt="OnboardTicket Logo"
-              className="h-24 w-auto object-contain"
-            />
-            <button
-              onClick={closeMenu}
-              className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
-              aria-label="Close menu"
-            >
-              <X className="w-5 h-5 text-brand-text-primary" />
-            </button>
-          </div>
+            {/* Menu Items */}
+            <div className="flex-1 p-4 space-y-4">
+              <button
+                className="w-full text-left px-4 py-3 text-brand-text-primary font-bold text-lg hover:bg-gray-100 rounded-lg transition-colors"
+                onClick={() => handleNavigation("/contact")}
+              >
+                Get Support
+              </button>
 
-          {/* Menu Items */}
-          <div className="flex-1 p-4 space-y-4">
-            <button
-              className="w-full text-left px-4 py-3 text-brand-text-primary font-bold text-lg hover:bg-gray-100 rounded-lg transition-colors"
-              onClick={() => handleNavigation("/contact")}
-            >
-              Get Support
-            </button>
+              {isAuthenticated ? (
+                <>
+                  <button
+                    className="w-full flex items-center gap-3 px-4 py-3 bg-[#3839C9] text-white font-bold text-lg rounded-lg hover:bg-blue-700 transition-colors"
+                    onClick={() => handleNavigation("/dashboard")}
+                  >
+                    <User className="w-5 h-5" />
+                    Dashboard
+                  </button>
+                  <button
+                    className="w-full flex items-center gap-3 px-4 py-3 text-brand-text-primary font-bold text-lg hover:bg-gray-100 rounded-lg transition-colors"
+                    onClick={handleLogout}
+                  >
+                    <LogOut className="w-5 h-5" />
+                    Logout
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    className="w-full text-left px-4 py-3 text-brand-text-primary font-medium text-base hover:bg-gray-100 rounded-lg transition-colors"
+                    onClick={() => handleNavigation("/guest-booking-lookup")}
+                  >
+                    Find Booking
+                  </button>
+                  <button
+                    className="w-full text-left px-4 py-3 text-brand-text-primary font-bold text-lg hover:bg-gray-100 rounded-lg transition-colors"
+                    onClick={() => handleNavigation("/login")}
+                  >
+                    Sign In
+                  </button>
+                  <button
+                    className="w-full text-left px-4 py-3 bg-white text-brand-text-primary font-bold text-lg rounded-lg hover:bg-gray-50 transition-colors border-2 border-gray-200"
+                    onClick={handleBookNowClick}
+                  >
+                    Book now
+                  </button>
+                </>
+              )}
+            </div>
 
-            {isAuthenticated ? (
-              <>
-                <button
-                  className="w-full flex items-center gap-3 px-4 py-3 bg-[#3839C9] text-white font-bold text-lg rounded-lg hover:bg-blue-700 transition-colors"
-                  onClick={() => handleNavigation("/dashboard")}
-                >
-                  <User className="w-5 h-5" />
-                  Dashboard
-                </button>
-                <button
-                  className="w-full flex items-center gap-3 px-4 py-3 text-brand-text-primary font-bold text-lg hover:bg-gray-100 rounded-lg transition-colors"
-                  onClick={handleLogout}
-                >
-                  <LogOut className="w-5 h-5" />
-                  Logout
-                </button>
-              </>
-            ) : (
-              <>
-                <button
-                  className="w-full text-left px-4 py-3 text-brand-text-primary font-medium text-base hover:bg-gray-100 rounded-lg transition-colors"
-                  onClick={() => handleNavigation("/guest-booking-lookup")}
-                >
-                  Find Booking
-                </button>
-                <button
-                  className="w-full text-left px-4 py-3 text-brand-text-primary font-bold text-lg hover:bg-gray-100 rounded-lg transition-colors"
-                  onClick={() => handleNavigation("/login")}
-                >
-                  Sign In
-                </button>
-                <button
-                  className="w-full text-left px-4 py-3 bg-white text-brand-text-primary font-bold text-lg rounded-lg hover:bg-gray-50 transition-colors border-2 border-gray-200"
-                  onClick={handleBookNowClick}
-                >
-                  Book now
-                </button>
-              </>
-            )}
-          </div>
-
-          {/* User Info (if authenticated) */}
-          {isAuthenticated && user && (
-            <div className="border-t p-4">
-              <div className="flex items-center gap-3 bg-gray-50 rounded-lg p-3">
-                <div className="w-10 h-10 bg-[#3839C9] rounded-full flex items-center justify-center">
-                  <User className="w-5 h-5 text-white" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="font-semibold text-gray-900 text-sm">
-                    {user.firstName} {user.lastName}
+            {/* User Info (if authenticated) */}
+            {isAuthenticated && user && (
+              <div className="border-t p-4">
+                <div className="flex items-center gap-3 bg-gray-50 rounded-lg p-3">
+                  <div className="w-10 h-10 bg-[#3839C9] rounded-full flex items-center justify-center">
+                    <User className="w-5 h-5 text-white" />
                   </div>
-                  <div className="text-xs text-gray-500 truncate">
-                    {user.email}
+                  <div className="flex-1 min-w-0">
+                    <div className="font-semibold text-gray-900 text-sm">
+                      {user.firstName} {user.lastName}
+                    </div>
+                    <div className="text-xs text-gray-500 truncate">
+                      {user.email}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 MobileNav.displayName = "MobileNav";
 

--- a/client/components/MobileNav.tsx
+++ b/client/components/MobileNav.tsx
@@ -5,9 +5,10 @@ import { useAuth } from "../hooks/useAuth";
 
 interface MobileNavProps {
   handleBookNow: () => void;
+  className?: string;
 }
 
-const MobileNav: React.FC<MobileNavProps> = memo(({ handleBookNow }) => {
+const MobileNav: React.FC<MobileNavProps> = memo(({ handleBookNow, className }) => {
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
   const { user, logout, isAuthenticated } = useAuth();
@@ -36,7 +37,7 @@ const MobileNav: React.FC<MobileNavProps> = memo(({ handleBookNow }) => {
   const toggleMenu = useCallback(() => setIsOpen((prev) => !prev), []);
 
   return (
-    <div className="md:hidden">
+    <div className={className ?? "md:hidden"}>
       {/* Hamburger Button */}
       <button
         onClick={toggleMenu}

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -10,7 +10,7 @@ export default function About() {
   return (
     <div className="min-h-screen bg-[#F4F4FF] font-plus-jakarta">
       {/* Header */}
-      <header className="max-w-7xl mx-auto px-4 sm:px-8 lg:px-36 py-6 flex flex-col sm:flex-row justify-between items-center gap-4">
+      <header className="max-w-7xl mx-auto px-4 sm:px-8 lg:px-36 py-6 flex justify-between items-center">
         <div
           className="flex items-center cursor-pointer"
           onClick={() => navigate("/")}

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -1,7 +1,11 @@
 import { useNavigate } from "react-router-dom";
+import MobileNav from "../components/MobileNav";
 
 export default function About() {
   const navigate = useNavigate();
+  const handleBookNow = () => {
+    navigate("/userform/route");
+  };
 
   return (
     <div className="min-h-screen bg-[#F4F4FF] font-plus-jakarta">
@@ -19,7 +23,7 @@ export default function About() {
             onClick={() => navigate("/")}
           />
         </div>
-        <nav className="flex flex-col sm:flex-row gap-2 sm:gap-4 w-full sm:w-auto">
+        <nav className="hidden lg:flex items-center gap-4">
           <button
             className="px-4 sm:px-8 py-2 sm:py-3 text-ob-dark font-bold text-base sm:text-lg hover:bg-gray-100 rounded-lg transition-colors"
             onClick={() => navigate("/contact")}
@@ -33,6 +37,7 @@ export default function About() {
             Book now
           </button>
         </nav>
+        <MobileNav className="lg:hidden" handleBookNow={handleBookNow} />
       </header>
 
       {/* Main Content */}

--- a/client/pages/Contact.tsx
+++ b/client/pages/Contact.tsx
@@ -35,7 +35,7 @@ export default function Contact() {
   return (
     <div className="min-h-screen bg-[#F4F4FF] font-plus-jakarta">
       {/* Header */}
-      <header className="max-w-7xl mx-auto px-4 sm:px-8 lg:px-36 py-6 flex flex-col sm:flex-row justify-between items-center gap-4">
+      <header className="max-w-7xl mx-auto px-4 sm:px-8 lg:px-36 py-6 flex justify-between items-center">
         <div
           className="flex items-center cursor-pointer"
           onClick={() => navigate("/")}

--- a/client/pages/Contact.tsx
+++ b/client/pages/Contact.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { MessageCircle, BookOpen } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import ContactMenu from "./ContactMenu";
+import MobileNav from "../components/MobileNav";
 
 export default function Contact() {
   const navigate = useNavigate();
@@ -27,6 +28,10 @@ export default function Contact() {
     console.log("Form submitted:", formData);
   };
 
+  const handleBookNow = () => {
+    navigate("/userform/route");
+  };
+
   return (
     <div className="min-h-screen bg-[#F4F4FF] font-plus-jakarta">
       {/* Header */}
@@ -43,7 +48,7 @@ export default function Contact() {
             onClick={() => navigate("/")}
           />
         </div>
-        <nav className="flex flex-col sm:flex-row gap-2 sm:gap-4 w-full sm:w-auto">
+        <nav className="hidden lg:flex items-center gap-4">
           <button
             className="px-4 sm:px-8 py-2 sm:py-3 text-ob-dark font-bold text-base sm:text-lg hover:bg-gray-100 rounded-lg transition-colors"
             onClick={() => navigate("/contact")}
@@ -57,6 +62,7 @@ export default function Contact() {
             Book now
           </button>
         </nav>
+        <MobileNav className="lg:hidden" handleBookNow={handleBookNow} />
       </header>
 
       {/* Hero Section */}

--- a/client/pages/Faq.tsx
+++ b/client/pages/Faq.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import MobileNav from "../components/MobileNav";
 
 // FAQ Card Component (Single Card, Multiple Questions)
 const FaqCard = ({ faqs }: { faqs: { q: string; a: string }[] }) => {
@@ -154,10 +155,14 @@ export default function Faq() {
     },
   ];
 
+  const handleBookNow = () => {
+    navigate("/userform/route");
+  };
+
   return (
     <div className="min-h-screen bg-ob-background font-plus-jakarta">
       {/* Header */}
-      <header className="text-left">
+      <header className="max-w-7xl mx-auto px-4 sm:px-8 lg:px-36 py-6 flex justify-between items-center">
         <div
           className="flex items-center cursor-pointer"
           onClick={() => navigate("/")}
@@ -170,6 +175,7 @@ export default function Faq() {
             onClick={() => navigate("/")}
           />
         </div>
+        <MobileNav className="lg:hidden" handleBookNow={handleBookNow} />
       </header>
 
       {/* Hero Section */}

--- a/client/pages/PrivacyPolicy.tsx
+++ b/client/pages/PrivacyPolicy.tsx
@@ -1,7 +1,11 @@
 import { useNavigate } from "react-router-dom";
+import MobileNav from "../components/MobileNav";
 
 export default function PrivacyPolicy() {
   const navigate = useNavigate();
+  const handleBookNow = () => {
+    navigate("/userform/route");
+  };
 
   return (
     <div className="min-h-screen bg-ob-background font-plus-jakarta">
@@ -19,7 +23,7 @@ export default function PrivacyPolicy() {
             onClick={() => navigate("/")}
           />
         </div>
-        <nav className="flex flex-col sm:flex-row gap-2 sm:gap-4 w-full sm:w-auto">
+        <nav className="hidden lg:flex items-center gap-4">
           <button
             className="px-4 sm:px-8 py-2 sm:py-3 text-ob-dark font-bold text-base sm:text-lg hover:bg-gray-100 rounded-lg transition-colors"
             onClick={() => navigate("/contact")}
@@ -33,6 +37,7 @@ export default function PrivacyPolicy() {
             Book now
           </button>
         </nav>
+        <MobileNav className="lg:hidden" handleBookNow={handleBookNow} />
       </header>
 
       {/* Main Content */}

--- a/client/pages/PrivacyPolicy.tsx
+++ b/client/pages/PrivacyPolicy.tsx
@@ -10,7 +10,7 @@ export default function PrivacyPolicy() {
   return (
     <div className="min-h-screen bg-ob-background font-plus-jakarta">
       {/* Header */}
-      <header className="max-w-7xl mx-auto px-4 sm:px-8 lg:px-36 py-6 flex flex-col sm:flex-row justify-between items-center gap-4">
+      <header className="max-w-7xl mx-auto px-4 sm:px-8 lg:px-36 py-6 flex justify-between items-center">
         <div
           className="flex items-center cursor-pointer"
           onClick={() => navigate("/")}

--- a/client/pages/TermsConditions.tsx
+++ b/client/pages/TermsConditions.tsx
@@ -1,7 +1,11 @@
 import { useNavigate } from "react-router-dom";
+import MobileNav from "../components/MobileNav";
 
 export default function TermsConditions() {
   const navigate = useNavigate();
+  const handleBookNow = () => {
+    navigate("/userform/route");
+  };
 
   return (
     <div className="min-h-screen bg-ob-background font-plus-jakarta">
@@ -19,7 +23,7 @@ export default function TermsConditions() {
             onClick={() => navigate("/")}
           />
         </div>
-        <nav className="flex flex-col sm:flex-row gap-2 sm:gap-4 w-full sm:w-auto">
+        <nav className="hidden lg:flex items-center gap-4">
           <button
             className="px-4 sm:px-8 py-2 sm:py-3 text-ob-dark font-bold text-base sm:text-lg hover:bg-gray-100 rounded-lg transition-colors"
             onClick={() => navigate("/contact")}
@@ -33,6 +37,7 @@ export default function TermsConditions() {
             Book now
           </button>
         </nav>
+        <MobileNav className="lg:hidden" handleBookNow={handleBookNow} />
       </header>
 
       {/* Main Content */}

--- a/client/pages/TermsConditions.tsx
+++ b/client/pages/TermsConditions.tsx
@@ -10,7 +10,7 @@ export default function TermsConditions() {
   return (
     <div className="min-h-screen bg-ob-background font-plus-jakarta">
       {/* Header */}
-      <header className="max-w-7xl mx-auto px-4 sm:px-8 lg:px-36 py-6 flex flex-col sm:flex-row justify-between items-center gap-4">
+      <header className="max-w-7xl mx-auto px-4 sm:px-8 lg:px-36 py-6 flex justify-between items-center">
         <div
           className="flex items-center cursor-pointer"
           onClick={() => navigate("/")}


### PR DESCRIPTION
## Purpose

The user wanted to improve mobile navigation by showing only the logo on mobile and medium devices while moving navigation buttons (about, privacy policy, terms and conditions, FAQs, and contact) into a hamburger menu for better mobile UX.

## Code changes

- **Enhanced MobileNav component**: Added optional `className` prop to make the component more flexible for different breakpoint usage
- **Updated page headers**: Modified About, Contact, FAQ, Privacy Policy, and Terms & Conditions pages to:
  - Replace responsive flex layouts with fixed positioning
  - Hide navigation buttons on mobile/tablet (`hidden lg:flex`)
  - Add MobileNav component with `lg:hidden` class for mobile-only display
  - Implement `handleBookNow` function for mobile menu integration
- **Improved responsive design**: Navigation now cleanly switches between desktop horizontal layout and mobile hamburger menu at the `lg` breakpoint

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7ae4da599f664b8daa63c577ca747a47/orbit-realm)

👀 [Preview Link](https://7ae4da599f664b8daa63c577ca747a47-orbit-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7ae4da599f664b8daa63c577ca747a47</projectId>-->
<!--<branchName>orbit-realm</branchName>-->